### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/dikeshkumar135/10c83afd-e244-4df6-9f73-60f589a6870b/e16179be-2ea3-4eda-a4c0-209260b5ab30/_apis/work/boardbadge/a5e81ee2-7046-4454-898e-3064207fcd15)](https://dev.azure.com/dikeshkumar135/10c83afd-e244-4df6-9f73-60f589a6870b/_boards/board/t/e16179be-2ea3-4eda-a4c0-209260b5ab30/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#6](https://dev.azure.com/dikeshkumar135/10c83afd-e244-4df6-9f73-60f589a6870b/_workitems/edit/6). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.